### PR TITLE
fix exception on artifactory startup: "Could not create temporary pre store folder '/data/_pre'"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,8 @@
   file:
     path: "{{ artifactory_file_store_dir }}"
     state: directory
+    owner: "{{ artifactory_user }}"
+    group: "{{ artifactory_group }}"
 
 - name: configure artifactory
   template:


### PR DESCRIPTION
Im am using your role to install Artifactory on an CentOS 7 Vagrant Box (<https://app.vagrantup.com/centos/boxes/7>).

In my Ansible Playbook im am using

```
  remote_user: root
  become: true
```

to avoid an error when installing Artifactory.

After installation was successful I am getting the following exception:

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'binaryServiceImpl': Invocation of init method failed; nested exception is BinaryStorageException: 503 : Could not create temporary pre store folder '/data/_pre'
```

**Describe the change**
Setting owner and group information to `artifactory_owner` and `artifactory_group`.

**Testing**
1. My CentOS 7 based Ansible Playbook works now ;o)
1. ```image=centos tag=7 molecule test``` succeeds (as it did before)
