### PR TITLE
add missing requirement for ansible unarchive_module: unzip

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,6 +8,7 @@ _artifactory_requirements:
   RedHat:
     - procps
     - net-tools
+    - unzip
 
 artifactory_requirements: "{{ _artifactory_requirements[ansible_os_family] | default(_artifactory_requirements['default']) }}"
 


### PR DESCRIPTION
Im am using your role to install Artifactory on an CentOS 7 Vagrant Box (<https://app.vagrantup.com/centos/boxes/7>).

The task `download artifactory` does fail completely as the documented dependency **unzip** (<https://docs.ansible.com/ansible/latest/modules/unarchive_module.html#notes>) is not installed in this Vagrant Box.

**Describe the change**
Extended `_artifactory_requirements[RedHat]` with `- unzip`.

**Testing**
1. My CentOS 7 based Ansible Playbook works now ;o)
1. ```image=centos tag=7 molecule test``` succeeds (as it did before)