### PR TITLE
Enhancement: add molecule test dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Now you can start to edit on your laptop.
 Install [molecule](https://molecule.readthedocs.io/en/stable/) and [Tox](https://tox.readthedocs.io/):
 
 ```
-pip install molecule tox
+pip install molecule tox ansible-lint docker
 ```
 
 And run `molecule test`. If you want to test a specific distribution, set `image` and optionally `tag`:


### PR DESCRIPTION
When verifying #9 and #10 with `image=centos tag=7 molecule test` I had to install the following dependencies additional to the documented ones:

`pip install ansible-lint docker`

**Describe the change**
Updated CONTRIBUTING.md documentation to include ansible-lint and docker.

**Testing**
... ;o)