### PR TITLE
tasks/main.yml: wait for URL to be reachable and then output the URL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,3 +66,15 @@
     name: artifactory
     state: started
     enabled: true
+
+- name: Wait for URL to be reachable
+  ansible.builtin.uri:
+    url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:8082/ui/"
+  register: result
+  until: "result.status == 200"
+  retries: 31
+  delay: 10
+
+- name: Output URL
+  ansible.builtin.debug:
+    msg: "Artifactory is reachable here: http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:8082/ui/"


### PR DESCRIPTION
---
name: Pull request
about: Wait for Artifactory URL to be reachable, then output the URL

---

**Describe the change**
As it takes some time for Artifactory to start up, this MR adds a task to wait for the URL to be reachable. Once it is, it outputs the URL so the user is aware of the exact URL.

Fixes #13 

**Testing**
Worked properly in my tests (I created a vagrant setup for this, soon to be released).
